### PR TITLE
Dyndev bugfix + disable reboot

### DIFF
--- a/drivers/dyndev/dyndev_procfs.c
+++ b/drivers/dyndev/dyndev_procfs.c
@@ -277,7 +277,7 @@ static struct proc_dir_entry *create_procfs_entry(const char *path, const struct
         if (next_token) {
             // More segments follow, so this should be a directory
             if (!parent || !pde_subdir_find(parent, token, strlen(token))) {
-                printk(KERN_INFO "Creating directory: %s under parent\n", token);
+                //printk(KERN_INFO "Creating directory: %s under parent\n", token);
                 // Directory doesn't exist, so create it
                 parent = proc_mkdir(token, parent);
                 if (!parent) {
@@ -285,13 +285,14 @@ static struct proc_dir_entry *create_procfs_entry(const char *path, const struct
                     kfree(dup_path);
                     return ERR_PTR(-ENOMEM);
                 }
-            } // If directory exists, parent is already set to move into it for the next iteration
+            } else {
+                //printk(KERN_INFO "Directory: %s already exists\n", token);
+                parent = pde_subdir_find(parent, token, strlen(token));
+            }
         } else {
             // This is the last segment; decide based on the context if it's a file or directory
             struct proc_dir_entry *entry = proc_create(token, 0666, parent, proc_fops);
-            if (entry) {
-                printk(KERN_INFO "Created proc file: %s\n", token);
-            } else {
+            if (!entry) {
                 printk(KERN_WARNING "Failed to create proc file: %s\n", token);
             }
             kfree(dup_path);

--- a/kernel/reboot.c
+++ b/kernel/reboot.c
@@ -284,6 +284,9 @@ SYSCALL_DEFINE4(reboot, int, magic1, int, magic2, unsigned int, cmd,
 	char buffer[256];
 	int ret = 0;
 
+  printk("IGLOO: refusing to reboot\n");
+		return -EPERM;
+
 	/* We only trust the superuser with rebooting the system. */
 	if (!ns_capable(pid_ns->user_ns, CAP_SYS_BOOT))
 		return -EPERM;


### PR DESCRIPTION
In dyndev's procfs file creation logic, if adding a file within a subdirectory that exists, we need to update the `parent` variable in our loop.

Also disables reboot for the non-kernel panic case