### PR TITLE
Add clobbers to hypercalls

### DIFF
--- a/include/linux/hypercall.h
+++ b/include/linux/hypercall.h
@@ -11,7 +11,7 @@ static inline void igloo_hypercall(unsigned long num, unsigned long arg1) {
        "movz $0, $0, $0"
         : "+r"(reg0)
         : "r"(reg1) // num in register v0
-        : // No clobber
+        : "memory"
     );
 
 
@@ -22,7 +22,7 @@ static inline void igloo_hypercall(unsigned long num, unsigned long arg1) {
             "msr S0_0_c5_c0_0, xzr \n"
             : "+r"(reg1)
             : "r"(reg0)
-            : // No clobber
+            : "memory"
         );
 #elif defined(CONFIG_ARM) 
     register unsigned long reg0 asm("r7") = num;
@@ -32,7 +32,7 @@ static inline void igloo_hypercall(unsigned long num, unsigned long arg1) {
     "mcr p7, 0, r0, c0, c0, 0"
       : "+r"(reg1)
       : "r"(reg0)
-      :
+      : "memory"
   );  
 #elif defined(CONFIG_X86_64)
     register unsigned long reg0 asm("rax") = num;
@@ -42,7 +42,7 @@ static inline void igloo_hypercall(unsigned long num, unsigned long arg1) {
         "cpuid"
         : "+r"(reg0)           // hypercall num + return value in rax
         : "r"(reg1)            // arguments
-        : // No clobber
+        : "memory", "ebx", "ecx", "edx"  // No clobber
     );
 #else
 #error "No igloo_hypercall support for architecture"
@@ -58,7 +58,7 @@ static inline unsigned long igloo_hypercall2(unsigned long num, unsigned long ar
        "msr S0_0_c5_c0_0, xzr \n"
         : "+r"(reg1)  // Input and output
         : "r"(reg0), "r"(reg2)
-        : // No clobber
+        : "memory"
     );
     return reg1;
 #elif defined(CONFIG_ARM)
@@ -70,10 +70,8 @@ static inline unsigned long igloo_hypercall2(unsigned long num, unsigned long ar
        "mcr p7, 0, r0, c0, c0, 0"
         : "+r"(reg1)  // Input and output
         : "r"(reg0), "r"(reg2)
-        : // No clobber
+        : "memory"
     );
-
-
 
     return reg1;
 
@@ -86,7 +84,7 @@ static inline unsigned long igloo_hypercall2(unsigned long num, unsigned long ar
        "movz $0, $0, $0"
         : "+r"(reg0)  // Input and output in R0
         : "r"(reg1) , "r" (reg2)// arg2 in register A1
-        : // No clobber
+        : "memory"
     );
     return reg0;
 #elif defined(CONFIG_X86_64)
@@ -98,7 +96,7 @@ static inline unsigned long igloo_hypercall2(unsigned long num, unsigned long ar
         "cpuid"
         : "+r"(reg0)           // hypercall num + return value in rax
         : "r"(reg1), "r"(reg2) // arguments
-        : // No clobber
+        :  "memory", "ebx", "ecx", "edx"
     );
 
     return reg0;


### PR DESCRIPTION
- Mark all architectures as clobbering memory
- Mark x86_64 as clobbering EBX, ECX, EDX