### PR TITLE
Bugfixes for mount & sys_open logging

### DIFF
--- a/fs/open.c
+++ b/fs/open.c
@@ -1084,8 +1084,8 @@ long do_sys_open(int dfd, const char __user *filename, int flags, umode_t mode)
 			// Resolve the dfd to its absolute path
 			char *path = resolve_dfd_to_path(dfd, resolved_path, PATH_MAX);
 			if (IS_ERR(path)) {
-				error = PTR_ERR(path);
-				goto out_free_resolved;
+				// XXX: rare failure, shows up with cgroups
+				strlcpy(resolved_path, "/path_resolve_error", PATH_MAX);
 			}
 
 			// Concatenate the resolved path with the provided filename


### PR DESCRIPTION
* Clean up code checking for devfs remounts to allow easier printk-style debugging in the future
* Fix a bug in our changes to sys_open which would trigger during cmount initialization where there was a call to open with in invalid DFD and we were making the open fail because our logging couldn't handle it - this changes it to just log a failure but allow the open to continue