### PR TITLE
Fix #11

### DIFF
--- a/kernel/sched/core.c
+++ b/kernel/sched/core.c
@@ -2912,7 +2912,7 @@ context_switch(struct rq *rq, struct task_struct *prev,
 		igloo_hypercall(1595, next->real_parent ? next->real_parent->start_time : 0); // Parent create. XXX shifted 1k
 
 		// Tell us about the current VMAs
-		if (next->mm) log_mm(next->mm);
+		if (!IS_ERR_OR_NULL(next->mm)) log_mm(next->mm);
 	}
 
 	return finish_task_switch(prev);


### PR DESCRIPTION
This PR attempts to resolve an issue seen in #11 around unaligned kernel pointer accesses by changing the check for the `mm_struct` to `!IS_ERR_OR_NULL` which is more expansive than the current NULL pointer check.