### PR TITLE
Actually block mounts

### DIFF
--- a/fs/namespace.c
+++ b/fs/namespace.c
@@ -2755,38 +2755,29 @@ long do_mount(const char *dev_name, const char __user *dir_name,
 	if (retval)
 		return retval;
 
-	// IGLOOO: Prevent guest from replacing a hyperfs mount (i.e., don't allow guest to remount /dev after we've set it up for hyperfs). Note that when we first see the mount it's called fuse.hperfs, but later it's just called fuse.
-	/* Check if it's a remount attempt on /dev */
+	// IGLOO: Prevent guest from remounting one of our custom mounts
 	if (path.dentry && path.dentry->d_sb && path.dentry->d_sb->s_type &&
 		path.dentry->d_sb->s_type->name && path.dentry->d_name.name) {
 
+		// What filesystem type is the *mount point* - not the requested mount, but the filesystem
+		// we're mounting into. e.g., mounting tmpfs into /home/tmp would be of type ext2 if /home is ext2
+		// If we see a mount_type of fuse, it's likely that we're mounting into one of our fuse filesystems
 		const char *mount_type = path.dentry->d_sb->s_type->name;
-		const char *mount_point = path.dentry->d_name.name;
+		const char *mount_point = path.dentry->d_name.name; // Name of the directory we're mounting (e.g., /dev -> dev)
 
-		//printk(KERN_INFO "Penguin: Current mount - point: %s, type: %s\n",
-		//       mount_point, mount_type);
+		//printk(KERN_INFO "Penguin: Requested mount point: %s, Requested mount type: %s, Actual mount type: %s\n",
+		//		mount_point, type_page ? type_page : "NULL", mount_type);
 
-		if (strcmp(mount_point, "dev") == 0 &&
-			strncmp("fuse", mount_type, 4) == 0 &&
-			type_page && strncmp("dev", type_page, 3) != 0) {
-
-			//printk(KERN_INFO "Penguin: Blocking attempt to remount /dev as %s\n", type_page);
-			retval = 0;  // Pretend it was okay
-			goto dput_out;
-		} else if (strcmp(mount_point, "sys") == 0 &&
-			strncmp("fuse", mount_type, 4) == 0 &&
-			type_page && strncmp("sys", type_page, 3) != 0) {
-
-			//printk(KERN_INFO "Penguin: Blocking attempt to remount /sys as %s\n", type_page);
-			retval = 0;  // Pretend it was okay
-			goto dput_out;
-		} else if (strcmp(mount_point, "proc") == 0 &&
-			strncmp("fuse", mount_type, 4) == 0 &&
-			type_page && strncmp("proc", type_page, 4) != 0) {
-
-			//printk(KERN_INFO "Penguin: Blocking attempt to remount /proc as %s\n", type_page);
-			retval = 0;  // Pretend it was okay
-			goto dput_out;
+		if (strncmp("fuse", mount_type, 4) == 0) {
+			// We're mounting something at a fuse mount point. For example, we might be remounting /dev after we've set up our initial fuse mount
+			// Let's check that it's one of the paths we care about: sys, dev, or proc. If so, we'll block it. Otherwise continue as normal
+			if (strncmp(mount_point, "dev", 3) == 0 ||
+				strncmp(mount_point, "sys", 3) == 0 ||
+				strncmp(mount_point, "proc", 4) == 0) {
+				//printk(KERN_INFO "Penguin: Blocking attempt to remount %s within a fuse as %s\n", mount_point, type_page ? type_page : "NULL");
+				retval = 0;  // Pretend it was okay
+				goto dput_out;
+			}
 		}
 	//} else {
 		//printk(KERN_WARNING "Penguin: Incomplete mount information\n");


### PR DESCRIPTION
* Fixes incorrect/incomplete logic in #13 that wasn't blocking remounts

I'm still not 100% sure this is right, but I had a test system where the old code was failing to block a remount of /proc. With this change the remount now fails as expected (and returns no error, also as expected).

The discussion I had with myself below is no longer relevant - those changes were moved into #18.