### PR TITLE
open.c: fix fd in igloo_open_hc()

### DIFF
--- a/fs/open.c
+++ b/fs/open.c
@@ -1053,10 +1053,6 @@ long do_sys_open(int dfd, const char __user *filename, int flags, umode_t mode)
 	if (IS_ERR(tmp))
 		return PTR_ERR(tmp);
 
-#ifdef CONFIG_IGLOO
-	igloo_hc_open(dfd, tmp, fd);
-#endif
-
 	fd = get_unused_fd_flags(flags);
 	if (fd >= 0) {
 		struct file *f = do_filp_open(dfd, tmp, &op);
@@ -1068,6 +1064,11 @@ long do_sys_open(int dfd, const char __user *filename, int flags, umode_t mode)
 			fd_install(fd, f);
 		}
 	}
+
+#ifdef CONFIG_IGLOO
+	igloo_hc_open(dfd, tmp, fd);
+#endif
+
 	putname(tmp);
 	return fd;
 }


### PR DESCRIPTION
If the call is too early, `fd` is always 0. Move it to the end of the function so it has the right value.